### PR TITLE
Fix Symfony 4.3 deprecation

### DIFF
--- a/src/Kiczort/PolishValidatorBundle/DependencyInjection/Configuration.php
+++ b/src/Kiczort/PolishValidatorBundle/DependencyInjection/Configuration.php
@@ -28,8 +28,13 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('kiczort_polish_validator');
+        $treeBuilder = new TreeBuilder('kiczort_polish_validator');
+        if (\method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('kiczort_polish_validator');
+        }
 
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for


### PR DESCRIPTION
It's done the same way as here:
* https://github.com/symfony/maker-bundle/commit/560d03cf68e3e9f1b9c
* https://github.com/doctrine/DoctrineBundle/commit/e711bed5a82437262a

Fixes #11