### PR TITLE
return docblock to supress deprecation warning in Symfony 5.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 composer.phar
 vendor/
 bin/
-
+.idea
 
 

--- a/src/Kiczort/PolishValidatorBundle/DependencyInjection/Configuration.php
+++ b/src/Kiczort/PolishValidatorBundle/DependencyInjection/Configuration.php
@@ -25,6 +25,7 @@ class Configuration implements ConfigurationInterface
 {
     /**
      * {@inheritdoc}
+     * @return TreeBuilder
      */
     public function getConfigTreeBuilder()
     {


### PR DESCRIPTION
I would recommend dropping support for Anything below Symfony 4.4 and PHP 7.1.3, merging symfony5-support to master and releasing new major version.

As this bundle is super stable this would be no problem to release v2.0 as Symfony 4.4+ compatible only.