### PR TITLE
Symfony 6 support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,98 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: PHP ${{ matrix.php-version }} + Symfony ${{ matrix.symfony-version }}
+
+    runs-on: ubuntu-18.04
+
+    continue-on-error: ${{ matrix.experimental }}
+
+    strategy:
+      matrix:
+        include:
+          - php-version: '7.1'
+            symfony-version: '^4.4'
+            composer-version: v1
+            stability: stable
+            coverage: none
+            experimental: false
+          - php-version: '7.2'
+            symfony-version: '^4.4'
+            composer-version: v1
+            stability: stable
+            coverage: none
+            experimental: false
+          - php-version: '7.2'
+            symfony-version: '^5.0'
+            composer-version: v1
+            stability: stable
+            coverage: none
+            experimental: false
+          - php-version: '7.3'
+            symfony-version: '^5.0'
+            composer-version: v1
+            stability: stable
+            coverage: none
+            experimental: false
+          - php-version: '7.4'
+            symfony-version: '^5.0'
+            composer-version: v2
+            stability: stable
+            coverage: xdebug
+            experimental: false
+          - php-version: '8.0'
+            symfony-version: '^5.0'
+            composer-version: v2
+            stability: RC
+            coverage: none
+            experimental: false
+          - php-version: '8.1'
+            symfony-version: '^5.0'
+            composer-version: v2
+            stability: RC
+            coverage: none
+            experimental: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          coverage: ${{ matrix.coverage }}
+          ini-values: "memory_limit=-1"
+          php-version: ${{ matrix.php-version }}
+          tools: composer:${{ matrix.composer-version }}
+
+      - name: Validate composer.json
+        run: composer validate --no-check-lock
+
+      - name: Configure Symfony version
+        run: composer require --no-update symfony/framework-bundle "${{ matrix.symfony-version }}"
+
+      - name: Configure composer stability
+        if: matrix.stability != 'stable'
+        run: composer config minimum-stability "${{ matrix.stability }}"
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v1
+        with:
+          composer-options: "--prefer-dist"
+
+      - name: Setup problem matchers for PHP
+        run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+
+      - name: Setup problem matchers for PHPUnit
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Run PHPUnit
+        if: matrix.coverage == 'none'
+        run: vendor/phpunit/phpunit/phpunit
+
+      - name: Run PHPUnit with coverage
+        if: matrix.coverage != 'none'
+        run: vendor/phpunit/phpunit/phpunit --coverage-clover=coverage.clover

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 composer.phar
 vendor/
 bin/
-
+.idea
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ composer.phar
 vendor/
 bin/
 .idea
-
+.phpunit.result.cache
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,12 @@ cache:
     - $HOME/.composer/cache/files
 
 php:
-- 5.6
-- 7.0
 - 7.1
 - 7.2
+- 7.3
+- 7.4
+- 8.0
+- 8.1
 
 env:
 - COMPOSER_FLAGS='update --prefer-lowest --prefer-stable'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Symfony2 bundle with Polish validators 
+Symfony bundle with Polish validators 
 ==================================
 
 [![License](https://img.shields.io/packagist/l/kiczort/polish-validator-bundle.svg)](https://packagist.org/packages/kiczort/polish-validator-bundle)
@@ -7,7 +7,7 @@ Symfony2 bundle with Polish validators
 [![Scrutinizer Quality Score](https://img.shields.io/scrutinizer/g/kiczort/polish-validator-bundle.svg)](https://scrutinizer-ci.com/g/kiczort/polish-validator-bundle/)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fkiczort%2Fpolish-validator-bundle.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fkiczort%2Fpolish-validator-bundle?ref=badge_shield)
 
-This is Symfony2 bundle with validators for Polish identification numbers like: PESEL, NIP, REGON and PWZ.
+This is Symfony bundle with validators for Polish identification numbers like: PESEL, NIP, REGON and PWZ.
  
  
 # Installation

--- a/composer.json
+++ b/composer.json
@@ -10,16 +10,16 @@
         }
     ],
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.1.3",
         "kiczort/polish-validator": "^1.1",
-        "symfony/config" : "~3.2 || ~4.0 || ~5.0",
-        "symfony/http-kernel" : "~3.2 || ~4.0 || ~5.0",
-        "symfony/dependency-injection" : "~3.2 || ~4.0 || ~5.0",
-        "symfony/validator": "~3.2 || ~4.0 || ~5.0"
+        "symfony/config" : "~4.4 || ~5.0 || ~6.0",
+        "symfony/http-kernel" : "~4.4 || ~5.0 || ~6.0",
+        "symfony/dependency-injection" : "~4.4 || ~5.0 || ~6.0",
+        "symfony/validator": "~4.4 || ~5.0 || ~6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7 || ~7.0",
-        "symfony/phpunit-bridge": "~3.2 || ~4.0"
+        "phpunit/phpunit": "~7.0 || ~8.0 || ~9.0",
+        "symfony/phpunit-bridge": "~4.4 || ~5.0 || ~6.0"
     },
     "autoload": {
         "psr-0": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,6 @@
         convertWarningsToExceptions = "true"
         processIsolation            = "false"
         stopOnFailure               = "false"
-        syntaxCheck                 = "true"
         bootstrap                   = "vendor/autoload.php" >
 
     <testsuites>

--- a/src/Kiczort/PolishValidatorBundle/DependencyInjection/Configuration.php
+++ b/src/Kiczort/PolishValidatorBundle/DependencyInjection/Configuration.php
@@ -25,6 +25,7 @@ class Configuration implements ConfigurationInterface
 {
     /**
      * {@inheritdoc}
+     * @return TreeBuilder
      */
     public function getConfigTreeBuilder()
     {

--- a/src/Kiczort/PolishValidatorBundle/DependencyInjection/Configuration.php
+++ b/src/Kiczort/PolishValidatorBundle/DependencyInjection/Configuration.php
@@ -25,17 +25,11 @@ class Configuration implements ConfigurationInterface
 {
     /**
      * {@inheritdoc}
-     * @return TreeBuilder
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('kiczort_polish_validator');
-        if (\method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->getRootNode();
-        } else {
-            // BC layer for symfony/config 4.1 and older
-            $rootNode = $treeBuilder->root('kiczort_polish_validator');
-        }
+        $rootNode = $treeBuilder->getRootNode();
 
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for

--- a/src/Kiczort/PolishValidatorBundle/Tests/Constraints/NipValidatorTest.php
+++ b/src/Kiczort/PolishValidatorBundle/Tests/Constraints/NipValidatorTest.php
@@ -13,8 +13,9 @@ namespace Kiczort\PolishValidatorBundle\Tests\Constraints;
 
 use Kiczort\PolishValidatorBundle\Validator\Constraints\Nip;
 use Kiczort\PolishValidatorBundle\Validator\Constraints\NipValidator;
+use stdClass;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
-use Symfony\Component\Validator\Validation;
 
 /**
  * @author Grzegorz Koziński <gkozinski@gmail.com>
@@ -43,12 +44,10 @@ class NipValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
     public function testExpectsStringCompatibleType()
     {
-        $this->validator->validate(new \stdClass(), new Nip());
+        $this->expectException(UnexpectedTypeException::class);
+        $this->validator->validate(new stdClass(), new Nip());
     }
 
     /**
@@ -66,9 +65,9 @@ class NipValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidNip($nip)
     {
-        $constraint = new Nip(array(
+        $constraint = new Nip([
             'message' => 'myMessage',
-        ));
+        ]);
 
         $this->validator->validate($nip, $constraint);
 
@@ -82,9 +81,9 @@ class NipValidatorTest extends ConstraintValidatorTestCase
      */
     public function getValidNipNumbers()
     {
-        return array(
-            array('1234563218'),
-        );
+        return [
+            ['1234563218'],
+        ];
     }
 
     /**
@@ -92,17 +91,13 @@ class NipValidatorTest extends ConstraintValidatorTestCase
      */
     public function getInvalidNipNumbers()
     {
-        return array(
-            array('123456789'),
-            array('12345678901'),
-            array('0000000000'),
-            array('123456789a'),
-            array('1234563217'),
-        );
+        return [
+            ['123456789'],
+            ['12345678901'],
+            ['0000000000'],
+            ['123456789a'],
+            ['1234563217'],
+        ];
     }
 
-    protected function getApiVersion()
-    {
-        return Validation::API_VERSION_2_5_BC;
-    }
 }

--- a/src/Kiczort/PolishValidatorBundle/Tests/Constraints/PeselValidatorTest.php
+++ b/src/Kiczort/PolishValidatorBundle/Tests/Constraints/PeselValidatorTest.php
@@ -13,6 +13,7 @@ namespace Kiczort\PolishValidatorBundle\Tests\Constraints;
 
 use Kiczort\PolishValidatorBundle\Validator\Constraints\Pesel;
 use Kiczort\PolishValidatorBundle\Validator\Constraints\PeselValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 use Symfony\Component\Validator\Validation;
 
@@ -43,11 +44,9 @@ class PeselValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
     public function testExpectsStringCompatibleType()
     {
+        $this->expectException(UnexpectedTypeException::class);
         $this->validator->validate(new \stdClass(), new Pesel());
     }
 
@@ -66,9 +65,9 @@ class PeselValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidPeselStrict($pesel)
     {
-        $this->validator->validate($pesel, new Pesel(array(
+        $this->validator->validate($pesel, new Pesel([
             'strict' => true,
-        )));
+        ]));
 
         $this->assertNoViolation();
     }
@@ -78,9 +77,9 @@ class PeselValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidPesel($pesel)
     {
-        $constraint = new Pesel(array(
+        $constraint = new Pesel([
             'message' => 'myMessage',
-        ));
+        ]);
 
         $this->validator->validate($pesel, $constraint);
 
@@ -94,10 +93,10 @@ class PeselValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidPeselStrict($pesel)
     {
-        $constraint = new Pesel(array(
+        $constraint = new Pesel([
             'strict' => true,
             'message' => 'myMessage',
-        ));
+        ]);
 
         $this->validator->validate($pesel, $constraint);
 
@@ -111,10 +110,10 @@ class PeselValidatorTest extends ConstraintValidatorTestCase
      */
     public function getNoneStrictValidPeselNumbers()
     {
-        return array(
-            array('55813111111'),
-            array('44051401358'),
-        );
+        return [
+            ['55813111111'],
+            ['44051401358'],
+        ];
     }
 
     /**
@@ -122,9 +121,9 @@ class PeselValidatorTest extends ConstraintValidatorTestCase
      */
     public function getStrictValidPeselNumbers()
     {
-        return array(
-            array('44051401359'),
-        );
+        return [
+            ['44051401359'],
+        ];
     }
 
     /**
@@ -132,12 +131,12 @@ class PeselValidatorTest extends ConstraintValidatorTestCase
      */
     public function getNoneStrictInvalidPeselNumbers()
     {
-        return array(
-            array('12314'),
-            array('12314111111'),
-            array('55813211111'),
-            array('123a41f1111'),
-        );
+        return [
+            ['12314'],
+            ['12314111111'],
+            ['55813211111'],
+            ['123a41f1111'],
+        ];
     }
 
     /**
@@ -145,13 +144,9 @@ class PeselValidatorTest extends ConstraintValidatorTestCase
      */
     public function getStrictInvalidPeselNumbers()
     {
-        return array(
-            array('44051401358'),
-        );
+        return [
+            ['44051401358'],
+        ];
     }
 
-    protected function getApiVersion()
-    {
-        return Validation::API_VERSION_2_5_BC;
-    }
 }

--- a/src/Kiczort/PolishValidatorBundle/Tests/Constraints/PwzValidatorTest.php
+++ b/src/Kiczort/PolishValidatorBundle/Tests/Constraints/PwzValidatorTest.php
@@ -13,8 +13,9 @@ namespace Kiczort\PolishValidatorBundle\Tests\Constraints;
 
 use Kiczort\PolishValidatorBundle\Validator\Constraints\Pwz;
 use Kiczort\PolishValidatorBundle\Validator\Constraints\PwzValidator;
+use stdClass;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
-use Symfony\Component\Validator\Validation;
 
 /**
  * @author Michał Mleczko
@@ -35,12 +36,10 @@ class PwzValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
     public function testExpectsStringCompatibleType()
     {
-        $this->validator->validate(new \stdClass(), new Pwz());
+        $this->expectException(UnexpectedTypeException::class);
+        $this->validator->validate(new stdClass(), new Pwz());
     }
 
     /**
@@ -58,9 +57,9 @@ class PwzValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidPwz($pwz)
     {
-        $constraint = new Pwz(array(
+        $constraint = new Pwz([
             'message' => 'myMessage',
-        ));
+        ]);
 
         $this->validator->validate($pwz, $constraint);
 
@@ -74,15 +73,15 @@ class PwzValidatorTest extends ConstraintValidatorTestCase
      */
     public function getValidPwzNumbers()
     {
-        return array(
-            array('7305386'),
-            array('7520143'),
-            array('5773472'),
-            array('1241156'),
-            array('8839283'),
-            array('4470910'),
-            array('4850185'),
-        );
+        return [
+            ['7305386'],
+            ['7520143'],
+            ['5773472'],
+            ['1241156'],
+            ['8839283'],
+            ['4470910'],
+            ['4850185'],
+        ];
     }
 
     /**
@@ -90,13 +89,13 @@ class PwzValidatorTest extends ConstraintValidatorTestCase
      */
     public function getInvalidPwzNumbers()
     {
-        return array(
-            array('0'),
-            array('0000000000000'),
-            array('0000000'),
-            array('1111111'),
-            array('2222222'),
-        );
+        return [
+            ['0'],
+            ['0000000000000'],
+            ['0000000'],
+            ['1111111'],
+            ['2222222'],
+        ];
     }
 
     /**
@@ -107,8 +106,4 @@ class PwzValidatorTest extends ConstraintValidatorTestCase
         return new PwzValidator();
     }
 
-    protected function getApiVersion()
-    {
-        return Validation::API_VERSION_2_5_BC;
-    }
 }

--- a/src/Kiczort/PolishValidatorBundle/Tests/Constraints/RegonValidatorTest.php
+++ b/src/Kiczort/PolishValidatorBundle/Tests/Constraints/RegonValidatorTest.php
@@ -13,6 +13,7 @@ namespace Kiczort\PolishValidatorBundle\Tests\Constraints;
 
 use Kiczort\PolishValidatorBundle\Validator\Constraints\Regon;
 use Kiczort\PolishValidatorBundle\Validator\Constraints\RegonValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 use Symfony\Component\Validator\Validation;
 
@@ -35,11 +36,9 @@ class RegonValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
-     */
     public function testExpectsStringCompatibleType()
     {
+        $this->expectException(UnexpectedTypeException::class);
         $this->validator->validate(new \stdClass(), new Regon());
     }
 
@@ -58,9 +57,9 @@ class RegonValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidRegon($regon)
     {
-        $constraint = new Regon(array(
+        $constraint = new Regon([
             'message' => 'myMessage',
-        ));
+        ]);
 
         $this->validator->validate($regon, $constraint);
 
@@ -74,10 +73,10 @@ class RegonValidatorTest extends ConstraintValidatorTestCase
      */
     public function getValidRegonNumbers()
     {
-        return array(
-            array('123456785'),
-            array('12345678512347'),
-        );
+        return [
+            ['123456785'],
+            ['12345678512347'],
+        ];
     }
 
     /**
@@ -85,17 +84,17 @@ class RegonValidatorTest extends ConstraintValidatorTestCase
      */
     public function getInvalidRegonNumbers()
     {
-        return array(
-            array('12345678512346'),
-            array('123456786'),
-            array('12345678a'),
-            array('1234567890123'),
-            array('123456789012'),
-            array('12345678901'),
-            array('1234567890'),
-            array('123456789012345'),
-            array('12345678'),
-        );
+        return [
+            ['12345678512346'],
+            ['123456786'],
+            ['12345678a'],
+            ['1234567890123'],
+            ['123456789012'],
+            ['12345678901'],
+            ['1234567890'],
+            ['123456789012345'],
+            ['12345678'],
+        ];
     }
 
     /**
@@ -106,8 +105,4 @@ class RegonValidatorTest extends ConstraintValidatorTestCase
         return new RegonValidator();
     }
 
-    protected function getApiVersion()
-    {
-        return Validation::API_VERSION_2_5_BC;
-    }
 }

--- a/src/Kiczort/PolishValidatorBundle/Validator/Constraints/Nip.php
+++ b/src/Kiczort/PolishValidatorBundle/Validator/Constraints/Nip.php
@@ -25,7 +25,7 @@ class Nip extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return 'kiczort.validator.nip';
     }

--- a/src/Kiczort/PolishValidatorBundle/Validator/Constraints/NipValidator.php
+++ b/src/Kiczort/PolishValidatorBundle/Validator/Constraints/NipValidator.php
@@ -22,7 +22,7 @@ class NipValidator extends ValidatorAbstract
     /**
      * @return ValidatorInterface
      */
-    public function getBaseValidator()
+    public function getBaseValidator(): ValidatorInterface
     {
         return new \Kiczort\PolishValidator\NipValidator();
     }
@@ -31,15 +31,15 @@ class NipValidator extends ValidatorAbstract
      * @param Constraint $constraint
      * @return array
      */
-    public function getValidationOptions(Constraint $constraint)
+    public function getValidationOptions(Constraint $constraint): array
     {
-        return array();
+        return [];
     }
 
     /**
      * @return string
      */
-    public function getValidatorConstraintClass()
+    public function getValidatorConstraintClass(): string
     {
         return __NAMESPACE__ . '\Nip';
     }

--- a/src/Kiczort/PolishValidatorBundle/Validator/Constraints/Pesel.php
+++ b/src/Kiczort/PolishValidatorBundle/Validator/Constraints/Pesel.php
@@ -26,7 +26,7 @@ class Pesel extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return 'kiczort.validator.pesel';
     }

--- a/src/Kiczort/PolishValidatorBundle/Validator/Constraints/PeselValidator.php
+++ b/src/Kiczort/PolishValidatorBundle/Validator/Constraints/PeselValidator.php
@@ -22,7 +22,7 @@ class PeselValidator extends ValidatorAbstract
     /**
      * @return ValidatorInterface
      */
-    public function getBaseValidator()
+    public function getBaseValidator(): ValidatorInterface
     {
         return new \Kiczort\PolishValidator\PeselValidator();
     }
@@ -31,15 +31,15 @@ class PeselValidator extends ValidatorAbstract
      * @param Constraint $constraint
      * @return array
      */
-    public function getValidationOptions(Constraint $constraint)
+    public function getValidationOptions(Constraint $constraint): array
     {
-        return array('strict' => (bool) $constraint->strict);
+        return ['strict' => (bool) $constraint->strict];
     }
 
     /**
      * @return string
      */
-    public function getValidatorConstraintClass()
+    public function getValidatorConstraintClass(): string
     {
         return __NAMESPACE__ . '\Pesel';
     }

--- a/src/Kiczort/PolishValidatorBundle/Validator/Constraints/Pwz.php
+++ b/src/Kiczort/PolishValidatorBundle/Validator/Constraints/Pwz.php
@@ -25,7 +25,7 @@ class Pwz extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return 'kiczort.validator.pwz';
     }

--- a/src/Kiczort/PolishValidatorBundle/Validator/Constraints/PwzValidator.php
+++ b/src/Kiczort/PolishValidatorBundle/Validator/Constraints/PwzValidator.php
@@ -25,7 +25,7 @@ class PwzValidator extends ValidatorAbstract
     /**
      * @return ValidatorInterface
      */
-    public function getBaseValidator()
+    public function getBaseValidator(): ValidatorInterface
     {
         return new \Kiczort\PolishValidator\PwzValidator();
     }
@@ -34,15 +34,15 @@ class PwzValidator extends ValidatorAbstract
      * @param Constraint $constraint
      * @return array
      */
-    public function getValidationOptions(Constraint $constraint)
+    public function getValidationOptions(Constraint $constraint): array
     {
-        return array();
+        return [];
     }
 
     /**
      * @return string
      */
-    public function getValidatorConstraintClass()
+    public function getValidatorConstraintClass(): string
     {
         return __NAMESPACE__ . '\Pwz';
     }

--- a/src/Kiczort/PolishValidatorBundle/Validator/Constraints/Regon.php
+++ b/src/Kiczort/PolishValidatorBundle/Validator/Constraints/Regon.php
@@ -25,7 +25,7 @@ class Regon extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return 'kiczort.validator.regon';
     }

--- a/src/Kiczort/PolishValidatorBundle/Validator/Constraints/RegonValidator.php
+++ b/src/Kiczort/PolishValidatorBundle/Validator/Constraints/RegonValidator.php
@@ -22,7 +22,7 @@ class RegonValidator extends ValidatorAbstract
     /**
      * @return ValidatorInterface
      */
-    public function getBaseValidator()
+    public function getBaseValidator(): ValidatorInterface
     {
         return new \Kiczort\PolishValidator\RegonValidator();
     }
@@ -31,15 +31,15 @@ class RegonValidator extends ValidatorAbstract
      * @param Constraint $constraint
      * @return array
      */
-    public function getValidationOptions(Constraint $constraint)
+    public function getValidationOptions(Constraint $constraint): array
     {
-        return array();
+        return [];
     }
 
     /**
      * @return string
      */
-    public function getValidatorConstraintClass()
+    public function getValidatorConstraintClass(): string
     {
         return __NAMESPACE__ . '\Regon';
     }

--- a/src/Kiczort/PolishValidatorBundle/Validator/Constraints/ValidatorAbstract.php
+++ b/src/Kiczort/PolishValidatorBundle/Validator/Constraints/ValidatorAbstract.php
@@ -26,18 +26,18 @@ abstract class ValidatorAbstract extends ConstraintValidator
     /**
      * @return ValidatorInterface
      */
-    abstract public function getBaseValidator();
+    abstract public function getBaseValidator(): ValidatorInterface;
 
     /**
      * @param Constraint $constraint
      * @return array
      */
-    abstract public function getValidationOptions(Constraint $constraint);
+    abstract public function getValidationOptions(Constraint $constraint): array;
 
     /**
      * @return string
      */
-    abstract public function getValidatorConstraintClass();
+    abstract public function getValidatorConstraintClass(): string;
 
     /**
      * Checks if the passed value is valid.


### PR DESCRIPTION
- support for Symfony below 4.4 dropped (last mantained LTS)
- support for PHP below 7.1.3 dropped (required by Symfony 4.4)
- added support for Symfony 6
- added support for PHP 8.0 and 8.1
- added PhpUnit 9.0+ support
- rewritten tests for PhpUnit 9.0+ compatibility
- slight doc update

Added github workflow for testing against multiple PHP and Symfony Versions